### PR TITLE
rebuild numpyro 0.15.3 for py39 :snowflake:

### DIFF
--- a/recipe/0001-patch-jax-and-jaxlib-requirement.patch
+++ b/recipe/0001-patch-jax-and-jaxlib-requirement.patch
@@ -1,0 +1,27 @@
+From 8bb49ed0e7c3c3571aca97fc9c2080a6345d0304 Mon Sep 17 00:00:00 2001
+From: Jack Olivieri <jolivieri@anaconda.com>
+Date: Mon, 13 Jan 2025 13:51:46 +0100
+Subject: [PATCH] patch jax and jaxlib requirement
+
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index b47b0bc..9e118fc 100644
+--- a/setup.py
++++ b/setup.py
+@@ -9,8 +9,8 @@ import sys
+ from setuptools import find_packages, setup
+ 
+ PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
+-_jax_version_constraints = ">=0.4.25"
+-_jaxlib_version_constraints = ">=0.4.25"
++_jax_version_constraints = ">=0.4.25.dev20250110"
++_jaxlib_version_constraints = ">=0.4.25.dev20250110"
+ 
+ # Find version
+ for line in open(os.path.join(PROJECT_PATH, "numpyro", "version.py")):
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ build:
   # Missing jax and jaxlib for s390x
   # The numpyro max version python 3.11
   skip: True  # [py>311 or s390x]
+  # skipping py39 on win because of missing jax and jaxlib
+  skip: True  # [win and py==39]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,10 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
-  # Missing jax and jaxlib python version 3.9
-  # https://github.com/jax-ml/jax/blob/jax-v0.4.35/setup.py#L118
+  number: 1
   # Missing jax and jaxlib for s390x
   # The numpyro max version python 3.11
-  skip: True  # [py<=39 or py>311 or s390x]
+  skip: True  # [py>311 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   # The numpyro max version python 3.11
   skip: True  # [py>311 or s390x]
   # skipping py39 on win because of missing jax and jaxlib
-  skip: True  # [win and py==39]
+  skip: True  # [win and py<=39]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/pyro-ppl/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: b8fbcc259575dfb9068e947015acde42b389772141a0d24acc640d2335e16d99
+  patches:
+    - 0001-patch-jax-and-jaxlib-requirement.patch
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -17,6 +19,9 @@ build:
   skip: True  # [py>311 or s390x]
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip


### PR DESCRIPTION
numpyro 0.15.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6667]
- dev_url:        https://github.com/pyro-ppl/numpyro/tree/0.15.3
- conda_forge:    https://github.com/conda-forge/numpyro-feedstock
- pypi:           https://pypi.org/project/numpyro/0.15.3
- pypi inspector: https://inspector.pypi.io/project/numpyro/0.15.3

### Related PRs:
- https://github.com/AnacondaRecipes/jaxlib-feedstock/pull/14
- https://github.com/AnacondaRecipes/jax-feedstock/pull/7

### Explanation of changes:

- new version number
- rebuild for `py39`
- modified requirement on `jax` and `jaxlib` as it seems those were built with version `0.4.25.dev20250110`
- skipping win-64 and `py39` because of missing `jax` and `jaxlib`, which, since this goes to `sfe1ed40`, is fine


[PKG-6667]: https://anaconda.atlassian.net/browse/PKG-6667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ